### PR TITLE
Store datetime in storable (ISO 8601) format

### DIFF
--- a/Tests/MyTasks.tests.ps1
+++ b/Tests/MyTasks.tests.ps1
@@ -125,11 +125,11 @@ Add-MyTaskCategory -Category Work,Personal,Other,Training,Testing
 
     It "Should modify a task by name" {
         $yr = (Get-Date).year+1
-        Set-MyTask -Name "Test1" -Progress 50 -Description "Pester Test" -DueDate "8/1/$yr"
+        Set-MyTask -Name "Test1" -Progress 50 -Description "Pester Test" -DueDate "$yr-1-8"
          $t = Get-MyTask -name Test1
          $t.Progress | should be 50
          $t.description | should be "Pester Test"
-         $t.duedate | Should be ("8/1/$yr" -as [datetime])
+         $t.duedate | Should be ("$yr-1-8" -as [datetime])
          $t.OverDue | Should be $false
     }
 
@@ -168,6 +168,7 @@ Add-MyTaskCategory -Category Work,Personal,Other,Training,Testing
     }
     
     It "Should remove a task and backup the task file" {
+        Copy-Item -Path $mytaskPath -Destination c:\temp\task.xml
         {Remove-myTask -Name Alice } | Should not Throw
         {Get-MyTask -Name Bob | Remove-MyTask } | should not Throw
         (Get-MyTask -all).count | Should be 1

--- a/Tests/MyTasks.tests.ps1
+++ b/Tests/MyTasks.tests.ps1
@@ -168,7 +168,6 @@ Add-MyTaskCategory -Category Work,Personal,Other,Training,Testing
     }
     
     It "Should remove a task and backup the task file" {
-        Copy-Item -Path $mytaskPath -Destination c:\temp\task.xml
         {Remove-myTask -Name Alice } | Should not Throw
         {Get-MyTask -Name Bob | Remove-MyTask } | should not Throw
         (Get-MyTask -all).count | Should be 1


### PR DESCRIPTION
These commits adjust the datetime strings being saved into the xml file to ISO 8601 formats so they are culture agnostic.

This being done via `Get-Date [...] -Format 's'`

Test cases were also adjusted so that they work in other cultures.

All pester tests worked in my culture (en-NZ - dd/mm/yyyy), but I **didn't** change to en-US to test that it still works as expected there.